### PR TITLE
Don't compare null to an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 module.exports = shallow
 
 function shallow(a, b, compare) {
+  var aIsNull = a === null
+  var bIsNull = b === null
+
+  if (aIsNull !== bIsNull) return false
+
   var aIsArray = Array.isArray(a)
   var bIsArray = Array.isArray(b)
 

--- a/test.js
+++ b/test.js
@@ -54,6 +54,11 @@ test('objects', function(t) {
   ), 'custom comparator')
 
   t.notOk(equals(
+      {}
+    , null
+  ), 'comparing to null')
+
+  t.notOk(equals(
       { a: 'b', b: 'c', a: 'a' }
     , { a: 'a', b: 'b', c: 'c' }
   ), 'same contents, different order')
@@ -77,6 +82,7 @@ test('objects', function(t) {
 })
 
 test('other', function(t) {
+  t.ok(equals(null, null), 'null')
   t.ok(equals('hello', 'hello'), 'simplest use case')
   t.ok(equals('hello', 'HELLO', function(a, b) {
     return a.toUpperCase() === b


### PR DESCRIPTION
Because `typeof null === 'object'` the code fell through to the `shallowObject` function and errored accessing keys on null.
